### PR TITLE
Fix Baganator integration, and add Baganator Warbank support (mainline)

### DIFF
--- a/LargerMacroIconSelection.lua
+++ b/LargerMacroIconSelection.lua
@@ -56,20 +56,26 @@ function LMIS:ADDON_LOADED(event, addon)
 	end
 end
 
-function LMIS:PLAYER_LOGIN(event)
-	if self.isMainline then
-		EventUtil.ContinueOnAddOnLoaded("Baganator", function()
+function LMIS:BANKFRAME_OPENED()
+	self:UnregisterEvent("BANKFRAME_OPENED")
+	EventUtil.ContinueOnAddOnLoaded("Baganator", function()
+		-- Usually both frames (single and category) exist after BANKFRAME_OPENED, but just to be safe…
+		if Baganator_SingleViewBankViewFrameblizzard then
 			self:Initialize(Baganator_SingleViewBankViewFrameblizzard.Character.TabSettingsMenu)
+			self:Initialize(Baganator_SingleViewBankViewFrameblizzard.Warband.TabSettingsMenu)
+		end
+		if Baganator_CategoryViewBankViewFrameblizzard then
 			self:Initialize(Baganator_CategoryViewBankViewFrameblizzard.Character.TabSettingsMenu)
-		end)
-	end
+			self:Initialize(Baganator_CategoryViewBankViewFrameblizzard.Warband.TabSettingsMenu)
+		end
+	end)
 end
 
 function LMIS:OnEvent(event, ...)
 	self[event](self, event, ...)
 end
 
-LMIS:RegisterEvent("PLAYER_LOGIN")
+if LMIS.isMainline then LMIS:RegisterEvent("BANKFRAME_OPENED") end
 LMIS:RegisterEvent("ADDON_LOADED")
 LMIS:SetScript("OnEvent", LMIS.OnEvent)
 


### PR DESCRIPTION
- The relevant Baganator frames do not yet exist at login, so we initialize at BANKFRAME_OPENED.
- PLAYER_LOGIN event registration removed, since it was only used for this.
- Also added support for the Baganator Warband frames.
- Since I could only test on WoW TWW 11.2, and the BANKFRAME_OPENED event is currently exclusively used for this thing, I’ve moved the `isMainline` test to the event registration (before, it was inside the event function, so the behavior remains the same).
- Should fix #12.
